### PR TITLE
Fix typo in jpackage configuration options

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -187,7 +187,7 @@ runtime {
         skipInstaller = true
         if (OperatingSystem.current() == OperatingSystem.MAC_OS) jvmArgs.add("-XstartOnFirstThread")
     }
-    options.set(listOf("--strip-debug", "--compress", "1", "--no--header-files", "--no-man-pages"))
+    options.set(listOf("--strip-debug", "--compress", "1", "--no-header-files", "--no-man-pages"))
     modules.set(listOf("jdk.unsupported", "java.management"))
 }
 


### PR DESCRIPTION
Option `--no-header-files` had an extra dash, making it `--no--header-files` causing the Gradle task to fail. The typo was introduced in commit https://github.com/openrndr/openrndr-template/commit/d1fbf470b2a74c4f28c7b11ed741ba6643710e0e