### PR TITLE
Fix launching custom Kt files from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ To create runnable jars for a platform different from the platform you use to bu
 
 ## Run other Kotlin programs from the command line
 
-By default the `run` task runs the program called `TemplateProgram.kt`.
-If you have other programs under your src/ folder and want
-to run them from the command line use
-`./gradlew -Papplication=MyProgram` to run `MyProgram.kt`.
-A full package name can be specified like this: `-Papplication=foo.bar.MyProgram`.
+By default `./gradlew run` runs a program called `TemplateProgram.kt` but a different one can be provided as an argument:
+
+To run `src/main/kotlin/myProgram.kt`
+
+    ./gradlew -Popenrndr.application=MyProgramKt
+
+To run `src/main/kotlin/foo/bar/myProgram.kt` (assuming `package foo.bar` in myProgram.kt)
+
+    ./gradlew -Popenrndr.application=foo.bar.MyProgramKt
 
 ## Github Actions
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,8 +141,8 @@ tasks.withType<KotlinCompile> {
 project.setProperty("mainClassName", applicationMainClass)
 
 application {
-    if (hasProperty("application")) {
-        mainClass.set("${property("application")}Kt")
+    if (hasProperty("openrndr.application")) {
+        mainClass.set("${property("openrndr.application")}")
     }
 }
 


### PR DESCRIPTION
The `application` property was already used.
Reusing it breaks things.
Use `openrndr.application` instead.