### PR TITLE
Add Gradle task to add scopes to IntelliJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -299,4 +299,29 @@ if (properties["openrndr.tasks"] == "true") {
         group = " \uD83E\uDD8C OPENRNDR"
         dependsOn("jpackageZip")
     }
+
+    task("add IDE file scopes") {
+        group = " \uD83E\uDD8C OPENRNDR"
+        val scopesFolder = File("${project.projectDir}/.idea/scopes")
+        scopesFolder.mkdirs()
+
+        val files = listOf(
+            "Code" to "file:*.kt||file:*.frag||file:*.vert||file:*.glsl",
+            "Text" to "file:*.txt||file:*.md||file:*.xml||file:*.json",
+            "Gradle" to "file[*buildSrc*]:*/||file:*gradle.*||file:*.gradle||file:*/gradle-wrapper.properties||file:*.toml",
+            "Images" to "file:*.png||file:*.jpg||file:*.dds||file:*.exr"
+        )
+        files.forEach { (name, pattern) ->
+            val file = File(scopesFolder, "__$name.xml")
+            if (!file.exists()) {
+                file.writeText(
+                    """
+                    <component name="DependencyValidationManager">
+                      <scope name=" ★ $name" pattern="$pattern" />
+                    </component>
+                    """.trimIndent()
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
Replaces https://github.com/openrndr/openrndr-template/pull/35

Adds a Gradle task which the user can use to add 4 useful scopes (code, text, images, gradle) to the project scopes menu.

By switching to Code the project view should look less scary to new users:
![image](https://user-images.githubusercontent.com/108264/234086508-58753e5b-e57d-4139-81fa-8ab0090b36f7.png)

The core idea is to not show always all files (noisy, more confusing), but a subset of the files in which the user is interested at any give moment.